### PR TITLE
Extract npm dependencies to package.json file and use it for travis

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 target/
 .idea/
+node_modules/
 
 # tut backups?
 .*.swp

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: java
 install:
-  - npm install xmldom
-  - npm install xhr2
+  - npm install
   - curl -L -o ~/sbt https://github.com/paulp/sbt-extras/raw/478a364a2d43d6e1ac4451f8b84cdafe43a2e43f/sbt
   - chmod +x ~/sbt
 os:

--- a/package.json
+++ b/package.json
@@ -1,0 +1,8 @@
+{
+  "repository": "https://github.com/alexarchambault/coursier.git",
+  "license": "Apache-2.0",
+  "devDependencies": {
+	"xmldom": "latest",
+	"xhr2": "latest"
+  }
+}


### PR DESCRIPTION
- Allows developers to init simply using `npm install`