### PR TITLE
Allow to disable progress bar display with the COURSIER_NO_TERM

### DIFF
--- a/cache/src/main/scala/coursier/TermDisplay.scala
+++ b/cache/src/main/scala/coursier/TermDisplay.scala
@@ -10,7 +10,7 @@ import scala.collection.mutable.ArrayBuffer
 
 class TermDisplay(
   out: Writer,
-  var fallbackMode: Boolean = false
+  var fallbackMode: Boolean = sys.env.get("COURSIER_NO_TERM").nonEmpty
 ) extends Cache.Logger {
 
   private val ansi = new Ansi(out)

--- a/plugin/src/main/scala-2.10/coursier/Tasks.scala
+++ b/plugin/src/main/scala-2.10/coursier/Tasks.scala
@@ -261,10 +261,7 @@ object Tasks {
 
         val pool = Executors.newFixedThreadPool(parallelDownloads, Strategy.DefaultDaemonThreadFactory)
 
-        def createLogger() = new TermDisplay(
-          new OutputStreamWriter(System.err),
-          fallbackMode = sys.env.get("COURSIER_NO_TERM").nonEmpty
-        )
+        def createLogger() = new TermDisplay(new OutputStreamWriter(System.err))
 
         val resLogger = createLogger()
 


### PR DESCRIPTION
environment variable by default

COURSIER_NO_TERM just has to be non-empty.