### PR TITLE
Better lookup of main class by launch command

### DIFF
--- a/cli/src/main/scala-2.11/coursier/cli/Launch.scala
+++ b/cli/src/main/scala-2.11/coursier/cli/Launch.scala
@@ -143,6 +143,13 @@ case class Launch(
     else {
       val mainClasses = Helper.mainClasses(loader)
 
+      if (options.common.verbosityLevel >= 2) {
+        Console.err.println("Found main classes:")
+        for (((vendor, title), mainClass) <- mainClasses)
+          Console.err.println(s"  $mainClass (vendor: $vendor, title: $title)")
+        Console.err.println("")
+      }
+
       val mainClass =
         if (mainClasses.isEmpty) {
           Helper.errPrintln("No main class found. Specify one with -M or --main.")


### PR DESCRIPTION
- have it only inspect the manifests of the loaded JARs, not those of coursier itself in particular
- print the found main classes if verbosity level >= 2