### PR TITLE
Put back bootstrap.jar in proguarded launcher

### DIFF
--- a/cli/src/main/scala-2.11/coursier/cli/Bootstrap.scala
+++ b/cli/src/main/scala-2.11/coursier/cli/Bootstrap.scala
@@ -1,7 +1,7 @@
 package coursier
 package cli
 
-import java.io.{ FileInputStream, ByteArrayOutputStream, File, IOException }
+import java.io.{ FileInputStream, ByteArrayInputStream, ByteArrayOutputStream, File, IOException }
 import java.nio.file.Files
 import java.nio.file.attribute.PosixFilePermission
 import java.util.Properties
@@ -121,7 +121,7 @@ case class Bootstrap(
 
   val buffer = new ByteArrayOutputStream()
 
-  val bootstrapZip = new ZipInputStream(Thread.currentThread().getContextClassLoader.getResourceAsStream("bootstrap.jar"))
+  val bootstrapZip = new ZipInputStream(new ByteArrayInputStream(bootstrapJar))
   val outputZip = new ZipOutputStream(buffer)
 
   for ((ent, data) <- zipEntries(bootstrapZip)) {


### PR DESCRIPTION
Fix the `bootstrap` command currently failing with the 1.0.0-M10 launcher.