### PR TITLE
Small fix

### DIFF
--- a/plugin/src/main/scala-2.10/coursier/CoursierPlugin.scala
+++ b/plugin/src/main/scala-2.10/coursier/CoursierPlugin.scala
@@ -41,8 +41,15 @@ object CoursierPlugin extends AutoPlugin {
     coursierFallbackDependencies <<= Tasks.coursierFallbackDependenciesTask,
     coursierCache := Cache.default,
     update <<= Tasks.updateTask(withClassifiers = false),
-    updateClassifiers <<= Tasks.updateTask(withClassifiers = true, ignoreArtifactErrors = true),
-    updateSbtClassifiers in Defaults.TaskGlobal <<= Tasks.updateTask(withClassifiers = true, sbtClassifiers = true),
+    updateClassifiers <<= Tasks.updateTask(
+      withClassifiers = true,
+      ignoreArtifactErrors = true
+    ),
+    updateSbtClassifiers in Defaults.TaskGlobal <<= Tasks.updateTask(
+      withClassifiers = true,
+      sbtClassifiers = true,
+      ignoreArtifactErrors = true
+    ),
     coursierProject <<= Tasks.coursierProjectTask,
     coursierProjects <<= Tasks.coursierProjectsTask,
     coursierPublications <<= Tasks.coursierPublicationsTask,


### PR DESCRIPTION
Should make updateSbtClassifiers not fail if some javadoc or source JARs
cannot be found (already fine in 1.0.0-M10, originates from changes that happenned since then).