### PR TITLE
Set default artifact type to JAR from sbt plugin

### DIFF
--- a/plugin/src/main/scala-2.10/coursier/CoursierPlugin.scala
+++ b/plugin/src/main/scala-2.10/coursier/CoursierPlugin.scala
@@ -12,6 +12,7 @@ object CoursierPlugin extends AutoPlugin {
   object autoImport {
     val coursierParallelDownloads = Keys.coursierParallelDownloads
     val coursierMaxIterations = Keys.coursierMaxIterations
+    val coursierDefaultArtifactType = Keys.coursierDefaultArtifactType
     val coursierChecksums = Keys.coursierChecksums
     val coursierArtifactsChecksums = Keys.coursierArtifactsChecksums
     val coursierCachePolicies = Keys.coursierCachePolicies
@@ -57,6 +58,7 @@ object CoursierPlugin extends AutoPlugin {
   override lazy val projectSettings = Seq(
     coursierParallelDownloads := 6,
     coursierMaxIterations := 50,
+    coursierDefaultArtifactType := "jar",
     coursierChecksums := Seq(Some("SHA-1"), None),
     coursierArtifactsChecksums := Seq(None),
     coursierCachePolicies := CachePolicy.default,

--- a/plugin/src/main/scala-2.10/coursier/FromSbt.scala
+++ b/plugin/src/main/scala-2.10/coursier/FromSbt.scala
@@ -49,10 +49,11 @@ object FromSbt {
     (module0, version)
   }
 
-    def dependencies(
+  def dependencies(
     module: ModuleID,
     scalaVersion: String,
-    scalaBinaryVersion: String
+    scalaBinaryVersion: String,
+    defaultArtifactType: String
   ): Seq[(String, Dependency)] = {
 
     // TODO Warn about unsupported properties in `module`
@@ -74,7 +75,7 @@ object FromSbt {
 
     val attributes =
       if (module.explicitArtifacts.isEmpty)
-        Seq(Attributes())
+        Seq(Attributes(defaultArtifactType, ""))
       else
         module.explicitArtifacts.map { a =>
           Attributes(`type` = a.extension, classifier = a.classifier.getOrElse(""))
@@ -105,14 +106,15 @@ object FromSbt {
     allDependencies: Seq[ModuleID],
     ivyConfigurations: Map[String, Seq[String]],
     scalaVersion: String,
-    scalaBinaryVersion: String
+    scalaBinaryVersion: String,
+    defaultArtifactType: String
   ): Project = {
 
     // FIXME Ignored for now - easy to support though
     // val sbtDepOverrides = dependencyOverrides.value
     // val sbtExclusions = excludeDependencies.value
 
-    val deps = allDependencies.flatMap(dependencies(_, scalaVersion, scalaBinaryVersion))
+    val deps = allDependencies.flatMap(dependencies(_, scalaVersion, scalaBinaryVersion, defaultArtifactType))
 
     Project(
       Module(

--- a/plugin/src/main/scala-2.10/coursier/Keys.scala
+++ b/plugin/src/main/scala-2.10/coursier/Keys.scala
@@ -12,6 +12,7 @@ import scala.concurrent.duration.Duration
 object Keys {
   val coursierParallelDownloads = SettingKey[Int]("coursier-parallel-downloads")
   val coursierMaxIterations = SettingKey[Int]("coursier-max-iterations")
+  val coursierDefaultArtifactType = SettingKey[String]("coursier-default-artifact-type")
   val coursierChecksums = SettingKey[Seq[Option[String]]]("coursier-checksums")
   val coursierArtifactsChecksums = SettingKey[Seq[Option[String]]]("coursier-artifacts-checksums")
   val coursierCachePolicies = SettingKey[Seq[CachePolicy]]("coursier-cache-policies")

--- a/plugin/src/main/scala-2.10/coursier/Tasks.scala
+++ b/plugin/src/main/scala-2.10/coursier/Tasks.scala
@@ -76,16 +76,22 @@ object Tasks {
 
       val allDependenciesTask = allDependencies.in(projectRef).get(state)
 
+      lazy val projId = projectID.in(projectRef).get(state)
+      lazy val sv = scalaVersion.in(projectRef).get(state)
+      lazy val sbv = scalaBinaryVersion.in(projectRef).get(state)
+      lazy val defaultArtifactType = coursierDefaultArtifactType.in(projectRef).get(state)
+
       for {
         allDependencies <- allDependenciesTask
       } yield {
 
         FromSbt.project(
-          projectID.in(projectRef).get(state),
+          projId,
           allDependencies,
           configurations.map { cfg => cfg.name -> cfg.extendsConfigs.map(_.name) }.toMap,
-          scalaVersion.in(projectRef).get(state),
-          scalaBinaryVersion.in(projectRef).get(state)
+          sv,
+          sbv,
+          defaultArtifactType
         )
       }
     }
@@ -240,13 +246,15 @@ object Tasks {
         if (sbtClassifiers) {
           val sv = scalaVersion.value
           val sbv = scalaBinaryVersion.value
+          val defaultArtifactType = coursierDefaultArtifactType.value
 
           val proj = FromSbt.project(
             cm.id,
             cm.modules,
             cm.configurations.map(cfg => cfg.name -> cfg.extendsConfigs.map(_.name)).toMap,
             sv,
-            sbv
+            sbv,
+            defaultArtifactType
           )
 
           val fallbackDeps = FromSbt.fallbackDependencies(
@@ -587,13 +595,15 @@ object Tasks {
         if (sbtClassifiers) {
           val sv = scalaVersion.value
           val sbv = scalaBinaryVersion.value
+          val defaultArtifactType = coursierDefaultArtifactType.value
 
           FromSbt.project(
             cm.id,
             cm.modules,
             cm.configurations.map(cfg => cfg.name -> cfg.extendsConfigs.map(_.name)).toMap,
             sv,
-            sbv
+            sbv,
+            defaultArtifactType
           )
         } else {
           val proj = coursierProject.value
@@ -800,13 +810,15 @@ object Tasks {
         val cm = coursierSbtClassifiersModule.value
         val sv = scalaVersion.value
         val sbv = scalaBinaryVersion.value
+        val defaultArtifactType = coursierDefaultArtifactType.value
 
         FromSbt.project(
           cm.id,
           cm.modules,
           cm.configurations.map(cfg => cfg.name -> cfg.extendsConfigs.map(_.name)).toMap,
           sv,
-          sbv
+          sbv,
+          defaultArtifactType
         )
       } else {
         val proj = coursierProject.value

--- a/plugin/src/sbt-test/sbt-coursier/zookeeper/build.sbt
+++ b/plugin/src/sbt-test/sbt-coursier/zookeeper/build.sbt
@@ -1,0 +1,10 @@
+scalaVersion := "2.11.8"
+
+libraryDependencies += "org.apache.zookeeper" % "zookeeper" % "3.5.0-alpha"
+
+coursierCachePolicies := {
+  if (sys.props("os.name").startsWith("Windows"))
+    coursierCachePolicies.value
+  else
+    Seq(coursier.CachePolicy.ForceDownload)
+}

--- a/plugin/src/sbt-test/sbt-coursier/zookeeper/project/plugins.sbt
+++ b/plugin/src/sbt-test/sbt-coursier/zookeeper/project/plugins.sbt
@@ -1,0 +1,11 @@
+{
+  val pluginVersion = sys.props.getOrElse(
+    "plugin.version",
+    throw new RuntimeException(
+      """|The system property 'plugin.version' is not defined.
+         |Specify this property using the scriptedLaunchOpts -D.""".stripMargin
+    )
+  )
+
+  addSbtPlugin("io.get-coursier" % "sbt-coursier" % pluginVersion)
+}

--- a/plugin/src/sbt-test/sbt-coursier/zookeeper/src/main/scala/Main.scala
+++ b/plugin/src/sbt-test/sbt-coursier/zookeeper/src/main/scala/Main.scala
@@ -1,0 +1,8 @@
+import java.io.File
+import java.nio.file.Files
+
+import org.apache.zookeeper.ZooKeeper
+
+object Main extends App {
+  Files.write(new File("output").toPath, classOf[ZooKeeper].getSimpleName.getBytes("UTF-8"))
+}

--- a/plugin/src/sbt-test/sbt-coursier/zookeeper/test
+++ b/plugin/src/sbt-test/sbt-coursier/zookeeper/test
@@ -1,0 +1,3 @@
+$ delete output
+> run
+$ exists output


### PR DESCRIPTION
Even if the packaging attribute of the dependency says the packaging is different (e.g. pom), this makes the plugin try to get a JAR anyway.

Fixes https://github.com/alexarchambault/coursier/issues/278