### PR TITLE
Fix version interval bug from kinesis producer pom.xml

### DIFF
--- a/core/shared/src/main/scala/coursier/core/Parse.scala
+++ b/core/shared/src/main/scala/coursier/core/Parse.scala
@@ -6,8 +6,9 @@ import coursier.core.compatibility._
 object Parse {
 
   def version(s: String): Option[Version] = {
-    if (s.isEmpty || s.exists(c => c != '.' && c != '-' && c != '_' && !c.letterOrDigit)) None
-    else Some(Version(s))
+    val trimmed = s.trim
+    if (trimmed.isEmpty || trimmed.exists(c => c != '.' && c != '-' && c != '_' && !c.letterOrDigit)) None
+    else Some(Version(trimmed))
   }
 
   def ivyLatestSubRevisionInterval(s: String): Option[VersionInterval] =

--- a/tests/shared/src/test/resources/resolutions/org.webjars.bower/malihu-custom-scrollbar-plugin/3.1.5
+++ b/tests/shared/src/test/resources/resolutions/org.webjars.bower/malihu-custom-scrollbar-plugin/3.1.5
@@ -1,3 +1,3 @@
-org.webjars.bower:jquery:3.1.0:compile
+org.webjars.bower:jquery:3.1.1:compile
 org.webjars.bower:jquery-mousewheel:3.1.13:compile
 org.webjars.bower:malihu-custom-scrollbar-plugin:3.1.5:compile

--- a/tests/shared/src/test/scala/coursier/test/VersionIntervalTests.scala
+++ b/tests/shared/src/test/scala/coursier/test/VersionIntervalTests.scala
@@ -133,7 +133,7 @@ object VersionIntervalTests extends TestSuite {
 
       'basic{
         val itv = Parse.versionInterval("[2.2,)").get
-        
+
         assert(!itv.contains(v21))
         assert(itv.contains(v22))
         assert(itv.contains(v23))
@@ -195,6 +195,10 @@ object VersionIntervalTests extends TestSuite {
         val s4 = "(1.1,1.3)"
         val itv4 = Parse.versionInterval(s4)
         assert(itv4 == Some(VersionInterval(Some(Version("1.1")), Some(Version("1.3")), false, false)))
+
+        val s5 = "(1.11.0, 1.12.0]"
+        val itv5 = Parse.versionInterval(s5)
+        assert(itv5 == Some(VersionInterval(Some(Version("1.11.0")), Some(Version("1.12.0")), false, true)))
       }
       'leftEmptyVersions {
         val s1 = "[,1.3]"


### PR DESCRIPTION
Originally found when trying to import [the latest amazon kinesis producer library's pom.xml](https://repo1.maven.org/maven2/com/amazonaws/amazon-kinesis-producer/0.12.0/amazon-kinesis-producer-0.12.0.pom)

Repros issue #355

Also fixes the breaking test `coursier.test.CentralTests.versionInterval`