### PR TITLE
scaladex cli api change & use scalaVersion from options

### DIFF
--- a/cli/src/main/scala-2.11/coursier/cli/Helper.scala
+++ b/cli/src/main/scala-2.11/coursier/cli/Helper.scala
@@ -191,7 +191,7 @@ class Helper(
       val res = Nondeterminism[Task].gather(scaladexRawDependencies.map { s =>
         val deps = scaladex.dependencies(
           s,
-          "2.11",
+          scalaVersion,
           if (verbosityLevel >= 2) Console.err.println(_) else _ => ()
         )
 

--- a/cli/src/main/scala-2.11/coursier/cli/scaladex/Scaladex.scala
+++ b/cli/src/main/scala-2.11/coursier/cli/scaladex/Scaladex.scala
@@ -74,7 +74,7 @@ case class Scaladex[F[_]](fetch: String => EitherT[F, String, String], F: Nondet
 
     val s = fetch(
       // FIXME Escaping
-      s"https://index.scala-lang.org/api/scastie/search?q=$name&target=$target&scalaVersion=$scalaVersion"
+      s"https://index.scala-lang.org/api/search?q=$name&target=$target&scalaVersion=$scalaVersion&cli=true"
     )
 
     s.flatMap(s => EitherT.fromDisjunction[F](s.decodeEither[List[Scaladex.SearchResult]].disjunction))
@@ -91,7 +91,7 @@ case class Scaladex[F[_]](fetch: String => EitherT[F, String, String], F: Nondet
 
     val s = fetch(
       // FIXME Escaping
-      s"https://index.scala-lang.org/api/scastie/project?organization=$organization&repository=$repository&artifact=$artifactName"
+      s"https://index.scala-lang.org/api/project?organization=$organization&repository=$repository&artifact=$artifactName"
     )
 
     s.flatMap(s => EitherT.fromDisjunction[F](s.decodeEither[Scaladex.ArtifactInfos].disjunction))
@@ -122,7 +122,6 @@ case class Scaladex[F[_]](fetch: String => EitherT[F, String, String], F: Nondet
     * Latest version only.
     */
   def dependencies(name: String, scalaVersion: String, logger: String => Unit): EitherT[F, String, Seq[(Module, String)]] = {
-
     val idx = name.indexOf('/')
     val orgNameOrError =
       if (idx >= 0) {


### PR DESCRIPTION
* Scaladex was updated to allow developers to specify cli artifact. It
  will only return projects and artifacts with cli enable

https://github.com/scalacenter/scaladex/commit/c2b865ebd10a280d8bf085d80f7a62e89b5778a2