### PR TITLE
Change default for use sbt credentials to true

### DIFF
--- a/sbt-coursier/src/main/scala-2.10/coursier/CoursierPlugin.scala
+++ b/sbt-coursier/src/main/scala-2.10/coursier/CoursierPlugin.scala
@@ -84,7 +84,7 @@ object CoursierPlugin extends AutoPlugin {
     coursierResolvers <<= Tasks.coursierResolversTask,
     coursierRecursiveResolvers <<= Tasks.coursierRecursiveResolversTask,
     coursierSbtResolvers <<= externalResolvers in updateSbtClassifiers,
-    coursierUseSbtCredentials := false,
+    coursierUseSbtCredentials := true,
     coursierCredentials := Map.empty,
     coursierFallbackDependencies <<= Tasks.coursierFallbackDependenciesTask,
     coursierCache := Cache.default,


### PR DESCRIPTION
Hi,
this PR is maybe more a question than change request. I recently add repository (nexus) with credentials to a project and found my self between a rock and a hard place.

Either use the normal sbt credentials mechanism and disallow the usage coursier for this project or I add coursier to the project specific plugins file and forcing every one to use coursier. I choose the later option, but this already leaded to an error, because some one copied the credentials to an other project without enabling the coursier plugin, this led to confused third person which doesn't know any thing about this, hasn't enabled coursier in its default configuration, and doesn't know what to do.

In my humble opinion it would be better set the default of `coursierUseSbtCredentials` to `true`, so all the problems above wouldn't appear at all and the default sbt documentation about credentials would be still true for coursier. I know the documentation stated that this introduce a global lock, but facing the problem above I like to ask is this a big problem and is it more pragmatic to accept a (little?) lock. Maybe there is an other way to solve this problem, without a global lock.

Kind regards